### PR TITLE
[FEAT] Add a sponsor button in the repository

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [eddiejaoude]


### PR DESCRIPTION
## Proposed Changes

  - Add a sponsor button in the repository.
    - If it doesn't work, someone with Administrator access should enable the sponsor button (**see the [GitHub Docs](https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/displaying-a-sponsor-button-in-your-repository)**).
